### PR TITLE
Remove redundant HTML attributes

### DIFF
--- a/app/helpers/asciicasts_helper.rb
+++ b/app/helpers/asciicasts_helper.rb
@@ -41,7 +41,7 @@ module AsciicastsHelper
   def embed_script(asciicast)
     src = asciicast_url(asciicast, format: :js)
     id = "asciicast-#{asciicast.to_param}"
-    %(<script type="text/javascript" src="#{src}" id="#{id}" async></script>)
+    %(<script src="#{src}" id="#{id}" async></script>)
   end
 
   def embed_html_link(asciicast)

--- a/app/views/layouts/_ga.html.erb
+++ b/app/views/layouts/_ga.html.erb
@@ -1,12 +1,12 @@
 <% if CFG.google_analytics_id %>
-<script type="text/javascript">
+<script>
 
   var _gaq = _gaq || [];
   _gaq.push(['_setAccount', '<%= CFG.google_analytics_id %>']);
   _gaq.push(['_trackPageview']);
 
   (function() {
-    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+    var ga = document.createElement('script'); ga.async = true;
     ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
     var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
   })();

--- a/lib/asciinema_web/templates/doc/embedding.html.md
+++ b/lib/asciinema_web/templates/doc/embedding.html.md
@@ -56,13 +56,13 @@ link on asciicast page.
 
 It looks like this:
 
-    <script type="text/javascript" src="https://asciinema.org/a/14.js" id="asciicast-14" async></script>
+    <script src="https://asciinema.org/a/14.js" id="asciicast-14" async></script>
 
 The player shows up right at the place where the script is pasted. Let's look
 at the following markup:
 
     <p>This is some text.</p>
-    <script type="text/javascript" src="https://asciinema.org/a/14.js" id="asciicast-14" async></script>
+    <scriptsrc="https://asciinema.org/a/14.js" id="asciicast-14" async></script>
     <p>This is some other text.</p>
 
 The player is displayed between the two paragraphs, as a `div` element with
@@ -76,7 +76,7 @@ tag.
 For example, to make the embedded player auto start playback when loaded and use
 big font, use the following script:
 
-    <script type="text/javascript" src="https://asciinema.org/a/14.js" id="asciicast-14" async data-autoplay="true" data-size="big"></script>
+    <script src="https://asciinema.org/a/14.js" id="asciicast-14" async data-autoplay="true" data-size="big"></script>
 
 ## Customizing the playback
 

--- a/spec/features/widget_spec.rb
+++ b/spec/features/widget_spec.rb
@@ -16,7 +16,7 @@ class TestWidgetController < ActionController::Base
       <html>
         <head></head>
         <body>
-          <script type="text/javascript" src="#{src}" id="#{id}" async></script>
+          <script src="#{src}" id="#{id}" async></script>
         </body>
       </html>
 EOS


### PR DESCRIPTION
The `type` attribute on `<script>`, `<style>`, and `<link>` elements has implicit default values. As long as those values are used, there’s no point in explicitly adding them to the markup.

See https://mathiasbynens.be/notes/html5-levels#type-attributes.

I spotted this in the embed snippet and wanted to fix it there, but ended up doing the same for all the instances across the codebase. :)