### PR TITLE
Full URL to embeded video in the footer of iframe

### DIFF
--- a/app/views/asciicasts/embed.html.slim
+++ b/app/views/asciicasts/embed.html.slim
@@ -1,7 +1,7 @@
 = player page.asciicast, page.playback_options
 p.powered
   ' Recorded with
-  a href=root_url target="_top" asciinema
+  a href=asciicast_url(page.asciicast) target="_top" asciinema
 
 javascript:
 


### PR DESCRIPTION
In case of embedded players it isn't trivial how to get to the asciinema's page with embedded video. 
This PR adds a full link inside iframe.