### PR TITLE
Direct, cached downloads

### DIFF
--- a/config/releases.exs
+++ b/config/releases.exs
@@ -30,7 +30,8 @@ if env.("S3_BUCKET") do
   config :asciinema, Asciinema.FileStore.S3,
     region: env.("S3_REGION"),
     bucket: env.("S3_BUCKET"),
-    path: "uploads/"
+    path: "uploads/",
+    proxy: !!env.("S3_PROXY_ENABLED")
 
   config :ex_aws,
     access_key_id: [{:system, "AWS_ACCESS_KEY_ID"}, :instance_role],

--- a/docker/nginx/asciinema.conf
+++ b/docker/nginx/asciinema.conf
@@ -2,8 +2,13 @@ upstream phoenix-server {
     server phoenix:4000 fail_timeout=0;
 }
 
-proxy_cache_path /cache levels=1:2 keys_zone=png_cache:10m max_size=10g
-                 inactive=14d use_temp_path=off;
+# asciicast cache
+proxy_cache_path /cache/cast levels=1:2 keys_zone=cast_cache:100m max_size=10g
+                 inactive=180d use_temp_path=off;
+
+# png cache
+proxy_cache_path /cache/png levels=1:2 keys_zone=png_cache:100m max_size=10g
+                 inactive=30d use_temp_path=off;
 
 map $http_x_forwarded_proto $real_scheme {
     default $http_x_forwarded_proto;
@@ -61,6 +66,41 @@ server {
         proxy_set_header Host $http_host;
         proxy_pass http://phoenix-server;
         proxy_redirect off;
+    }
+
+    location ~ ^/_proxy/asciicasts/(.+) {
+        internal;
+
+        set $redirect_uri      "$upstream_http_redirect_uri";
+        set $cache_key         "$1";
+
+        proxy_cache            cast_cache;
+        proxy_cache_key        $cache_key;
+        proxy_cache_lock       on;
+        proxy_cache_revalidate on;
+        proxy_cache_use_stale  error timeout updating http_500 http_502 http_503 http_504;
+        proxy_cache_valid      200 304 180d;
+
+        resolver 1.1.1.1;
+
+        gunzip on;
+
+        proxy_http_version     1.1;
+        proxy_set_header       Connection "";
+        proxy_hide_header      x-amz-id-2;
+        proxy_hide_header      x-amz-version-id;
+        proxy_hide_header      x-amz-request-id;
+        proxy_hide_header      x-amz-meta-server-side-encryption;
+        proxy_hide_header      x-amz-server-side-encryption;
+        proxy_hide_header      x-amz-replication-status;
+        proxy_hide_header      Set-Cookie;
+        proxy_ignore_headers   Set-Cookie;
+        proxy_intercept_errors on;
+
+        add_header             X-Cache-Status $upstream_cache_status;
+        add_header             access-control-allow-origin "*";
+
+        proxy_pass $redirect_uri;
     }
 }
 


### PR DESCRIPTION
This uses nginx's caching capability to serve asciicasts directly without additional redirect to S3. Opt-in, by setting `S3_PROXY_ENABLED=true` env var.