### PR TITLE
Allow serving asciinema from other than /

### DIFF
--- a/assets/css/_home.scss
+++ b/assets/css/_home.scss
@@ -2,7 +2,7 @@
   .cinema {
     padding-top: 0px;
     padding-bottom: 0px;
-    background-image: url("/images/home-bg.jpg");
+    background-image: url("../static/images/home-bg.jpg");
     background-position: 50%;
 
     .row {

--- a/assets/css/_source_sans_pro.css
+++ b/assets/css/_source_sans_pro.css
@@ -2,29 +2,29 @@
   font-family: 'Source Sans Pro';
   font-style: normal;
   font-weight: 300;
-  src: local('Source Sans Pro Light'), local('SourceSansPro-Light'), url('/fonts/SourceSansPro-Light.ttf') format('truetype');
+  src: local('Source Sans Pro Light'), local('SourceSansPro-Light'), url('../static/fonts/SourceSansPro-Light.ttf') format('truetype');
 }
 @font-face {
   font-family: 'Source Sans Pro';
   font-style: normal;
   font-weight: 400;
-  src: local('Source Sans Pro'), local('SourceSansPro-Regular'), url('/fonts/SourceSansPro-Regular.ttf') format('truetype');
+  src: local('Source Sans Pro'), local('SourceSansPro-Regular'), url('../static/fonts/SourceSansPro-Regular.ttf') format('truetype');
 }
 @font-face {
   font-family: 'Source Sans Pro';
   font-style: normal;
   font-weight: 600;
-  src: local('Source Sans Pro Semibold'), local('SourceSansPro-Semibold'), url('/fonts/SourceSansPro-Semibold.ttf') format('truetype');
+  src: local('Source Sans Pro Semibold'), local('SourceSansPro-Semibold'), url('../static/fonts/SourceSansPro-Semibold.ttf') format('truetype');
 }
 @font-face {
   font-family: 'Source Sans Pro';
   font-style: normal;
   font-weight: 700;
-  src: local('Source Sans Pro Bold'), local('SourceSansPro-Bold'), url('/fonts/SourceSansPro-Bold.ttf') format('truetype');
+  src: local('Source Sans Pro Bold'), local('SourceSansPro-Bold'), url('../static/fonts/SourceSansPro-Bold.ttf') format('truetype');
 }
 @font-face {
   font-family: 'Source Sans Pro';
   font-style: italic;
   font-weight: 400;
-  src: local('Source Sans Pro Italic'), local('SourceSansPro-It'), url('/fonts/SourceSansPro-Italic.ttf') format('truetype');
+  src: local('Source Sans Pro Italic'), local('SourceSansPro-It'), url('../static/fonts/SourceSansPro-Italic.ttf') format('truetype');
 }

--- a/assets/css/powerline-symbols.css
+++ b/assets/css/powerline-symbols.css
@@ -1,4 +1,4 @@
 @font-face {
   font-family: 'Powerline Symbols';
-  src: local('Powerline Symbols'), local('PowerlineSymbols'), url('/fonts/PowerlineSymbols.otf') format('opentype');
+  src: local('Powerline Symbols'), local('PowerlineSymbols'), url('../static/fonts/PowerlineSymbols.otf') format('opentype');
 }

--- a/assets/webpack.config.js
+++ b/assets/webpack.config.js
@@ -43,7 +43,16 @@ module.exports = (env, options) => {
           ]
         },
         {
-          test: /\.(woff(2)?|ttf|eot|svg)(\?v=\d+\.\d+\.\d+)?$/,
+          test: /\.jpg$/,
+          use: [
+            {
+              loader: 'file-loader',
+              options: { name: '[name].[ext]', outputPath: '../images' }
+            },
+          ],
+        },
+        {
+          test: /\.(woff(2)?|ttf|otf|eot|svg)(\?v=\d+\.\d+\.\d+)?$/,
           use: [
             {
               loader: 'file-loader',

--- a/lib/asciinema_web/auth.ex
+++ b/lib/asciinema_web/auth.ex
@@ -5,6 +5,7 @@ defmodule AsciinemaWeb.Auth do
   alias Plug.Conn
   alias Asciinema.Accounts.User
   alias Asciinema.Repo
+  alias AsciinemaWeb.Router.Helpers, as: Routes
 
   @user_key "warden.user.user.key"
   @one_year_in_secs 31_557_600
@@ -38,7 +39,7 @@ defmodule AsciinemaWeb.Auth do
     conn
     |> save_return_path
     |> put_flash(:info, msg)
-    |> redirect(to: "/login/new")
+    |> redirect(to: Routes.login_path(conn, :new))
     |> halt
   end
 
@@ -49,7 +50,7 @@ defmodule AsciinemaWeb.Auth do
   def require_admin(conn, _) do
     conn
     |> put_flash(:error, "Access denied.")
-    |> redirect(to: "/")
+    |> redirect(to: Routes.home_path(conn, :show))
     |> halt()
   end
 

--- a/lib/asciinema_web/controllers/api_token_controller.ex
+++ b/lib/asciinema_web/controllers/api_token_controller.ex
@@ -15,12 +15,12 @@ defmodule AsciinemaWeb.ApiTokenController do
       {:error, :token_invalid} ->
         conn
         |> put_flash(:error, "Invalid token. Make sure you pasted the URL correctly.")
-        |> redirect(to: "/")
+        |> redirect(to: Routes.home_path(conn, :show))
 
       {:error, :token_revoked} ->
         conn
         |> put_flash(:error, "This token has been revoked.")
-        |> redirect(to: "/")
+        |> redirect(to: Routes.home_path(conn, :show))
     end
   end
 

--- a/lib/asciinema_web/controllers/session_controller.ex
+++ b/lib/asciinema_web/controllers/session_controller.ex
@@ -45,8 +45,7 @@ defmodule AsciinemaWeb.SessionController do
   defp redirect_to_profile(conn) do
     case conn.assigns.current_user do
       %User{username: nil} ->
-        redirect(conn, to: "/username/new")
-
+        redirect(conn, to: Routes.username_path(conn, :new))
       %User{} = user ->
         redirect_back_or(conn, to: profile_path(user))
     end
@@ -56,6 +55,6 @@ defmodule AsciinemaWeb.SessionController do
     conn
     |> Auth.log_out()
     |> put_flash(:info, "See you later!")
-    |> redirect(to: "/")
+    |> redirect(to: Routes.home_path(conn, :show))
   end
 end

--- a/lib/asciinema_web/controllers/user_controller.ex
+++ b/lib/asciinema_web/controllers/user_controller.ex
@@ -26,7 +26,7 @@ defmodule AsciinemaWeb.UserController do
         conn
         |> Auth.log_in(user)
         |> put_flash(:info, "Welcome to asciinema!")
-        |> redirect(to: "/username/new")
+        |> redirect(to: Routes.username_path(conn, :new))
 
       {:error, :token_invalid} ->
         conn

--- a/lib/asciinema_web/endpoint.ex
+++ b/lib/asciinema_web/endpoint.ex
@@ -11,14 +11,18 @@ defmodule AsciinemaWeb.Endpoint do
     signing_salt: "qJL+3s0T"
   ]
 
-  socket "/socket", AsciinemaWeb.UserSocket, websocket: true
+  config = Application.get_env(:asciinema, __MODULE__)
+  url = Keyword.get(config, :url)
+  path = Keyword.get(url, :path, "/")
+
+  socket path <> "socket", AsciinemaWeb.UserSocket, websocket: true
 
   # Serve at "/" the static files from "priv/static" directory.
   #
   # You should set gzip to true if you are running phx.digest
   # when deploying your static files in production.
   plug Plug.Static,
-    at: "/",
+    at: path,
     from: :asciinema,
     gzip: true,
     only: ~w(css fonts images js favicon.ico robots.txt)

--- a/lib/asciinema_web/router.ex
+++ b/lib/asciinema_web/router.ex
@@ -127,9 +127,9 @@ defmodule AsciinemaWeb.Router.Helpers.Extra do
 
   def profile_path(%{id: id, username: username}) do
     if username do
-      "/~#{username}"
+      H.home_path(Endpoint, :show) <> "~#{username}"
     else
-      "/u/#{id}"
+      H.home_path(Endpoint, :show) <> "u/#{id}"
     end
   end
 

--- a/lib/asciinema_web/templates/home/show.html.eex
+++ b/lib/asciinema_web/templates/home/show.html.eex
@@ -15,7 +15,7 @@
 <pre><code>brew install asciinema
 </code></pre>
 
-<p>See other <a href='/docs/installation'>installation options</a>.</p>
+<p>See other <a href='<%= Routes.doc_path(@conn, :show, :installation) %>'>installation options</a>.</p>
                           <p>Start recording with:</p><pre>asciinema rec</pre>" data-toggle="popover" type="button" data-original-title="" title="">Start Recording</button>
         </p>
 
@@ -38,7 +38,7 @@
     <div class="row about">
       <div class="col-md-12">
         <h3>asciinema <em><abbr title="from English ASCII + from Ancient Greek κίνημα (kínēma, “movement”)">[as-kee-nuh-muh] </abbr></em>is a free and open source solution for recording
-          terminal sessions and sharing them on the web. Read about <a href="/docs/how-it-works">how it works</a>. </h3>
+          terminal sessions and sharing them on the web. Read about <a href="<%= Routes.doc_path(@conn, :show, :"how-it-works") %>">how it works</a>. </h3>
       </div>
     </div>
   </div>
@@ -53,7 +53,7 @@
         <p>Record right where you work - in a terminal.
           To start just run <code>asciinema rec</code>, to finish hit <kbd>Ctrl-D</kbd> or type <code>exit</code>. </p>
 
-        <p><a href="/docs/getting-started">Get started »</a></p>
+        <p><a href="<%= Routes.doc_path(@conn, :show, :"getting-started") %>">Get started »</a></p>
       </div>
 
       <div class="col-md-4">
@@ -69,7 +69,7 @@
 
         <p>Easily embed an asciicast player in your blog post, project documentation page or in your conference talk slides. </p>
 
-        <p><a href="/docs/embedding">See the embedding docs »</a></p>
+        <p><a href="<%= Routes.doc_path(@conn, :show, :embedding) %>">See the embedding docs »</a></p>
       </div>
     </div>
   </div>
@@ -93,7 +93,7 @@
           <% end %>
         </div>
 
-        <p><a class="btn btn-info" href="/explore">Explore more</a></p>
+        <p><a class="btn btn-info" href="<%= Routes.asciicast_path(@conn, :index) %>">Explore more</a></p>
       </div>
     </div>
   </div>

--- a/lib/asciinema_web/templates/layout/_footer.html.eex
+++ b/lib/asciinema_web/templates/layout/_footer.html.eex
@@ -5,10 +5,10 @@
     <div class="row">
       <div class="col-md-4 col-xs-12">
         <ul class="links">
-          <li><a href="/contributing">Contributing</a></li>
-          <li><a href="/tos">Terms of Service</a></li>
-          <li><a href="/privacy">Privacy Policy</a></li>
-          <li><a href="/contact">Contact</a></li>
+          <li><a href="<%= Routes.page_path(@conn, :contributing) %>">Contributing</a></li>
+          <li><a href="<%= Routes.page_path(@conn, :tos) %>">Terms of Service</a></li>
+          <li><a href="<%= Routes.page_path(@conn, :privacy) %>">Privacy Policy</a></li>
+          <li><a href="<%= Routes.page_path(@conn, :contact) %>">Contact</a></li>
         </ul>
       </div>
 

--- a/lib/asciinema_web/templates/layout/_header.html.eex
+++ b/lib/asciinema_web/templates/layout/_header.html.eex
@@ -1,7 +1,7 @@
 <header>
   <nav class="navbar navbar-expand-md navbar-dark bg-dark">
     <div class="container">
-      <a class="navbar-brand" href="/">
+      <a class="navbar-brand" href="<%= Routes.home_path(@conn, :show) %>">
         <img src="<%= Routes.static_path(@conn, "/images/logo-red.svg") %>">
       </a>
 
@@ -12,7 +12,7 @@
       <div class="collapse navbar-collapse" id="navbarNavDropdown">
         <ul class="navbar-nav mr-auto">
           <li class="nav-item">
-            <a class="nav-link" href="/explore">Watch</span></a>
+            <a class="nav-link" href="<%= Routes.asciicast_path(@conn, :index) %>">Watch</span></a>
           </li>
 
           <li class="nav-item">
@@ -28,7 +28,7 @@
           </li>
 
           <li class="nav-item">
-            <a class="nav-link" href="/about">About</a>
+            <a class="nav-link" href="<%= Routes.page_path(@conn, :about) %>">About</a>
           </li>
         </ul>
 
@@ -41,13 +41,13 @@
               </a>
               <div class="dropdown-menu">
                 <a class="dropdown-item" href="<%= profile_path(@current_user) %>">Profile</a>
-                <a class="dropdown-item" href="/user/edit">Settings</a>
+                <a class="dropdown-item" href="<%= Routes.user_path(@conn, :edit) %>">Settings</a>
                 <%= link "Log out", to: Routes.session_path(@conn, :delete), class: "dropdown-item logout", method: :delete %>
               </div>
             </li>
           <% else %>
             <li class="nav-item">
-              <a class="nav-link" href="/login/new" id="log-in">Log in / Sign up</a>
+              <a class="nav-link" href="<%= Routes.login_path(@conn, :new) %>" id="log-in">Log in / Sign up</a>
             </li>
           <% end %>
         </ul>

--- a/lib/asciinema_web/templates/layout/footer.html.eex
+++ b/lib/asciinema_web/templates/layout/footer.html.eex
@@ -5,10 +5,10 @@
     <div class="row">
       <div class="col-md-4 col-xs-4">
         <ul class="links">
-          <li><a href="/contributing">Contributing</a></li>
-          <li><a href="/tos">Terms of Service</a></li>
-          <li><a href="/privacy">Privacy Policy</a></li>
-          <li><a href="/contact">Contact</a></li>
+          <li><a href="<%= Routes.page_path(@conn, :contributing) %>">Contributing</a></li>
+          <li><a href="<%= Routes.page_path(@conn, :tos) %>">Terms of Service</a></li>
+          <li><a href="<%= Routes.page_path(@conn, :privacy) %>">Privacy Policy</a></li>
+          <li><a href="<%= Routes.page_path(@conn, :contact) %>">Contact</a></li>
         </ul>
       </div>
 

--- a/lib/asciinema_web/templates/layout/header.html.eex
+++ b/lib/asciinema_web/templates/layout/header.html.eex
@@ -7,18 +7,18 @@
         <span class="icon-bar"></span>
       </button>
 
-      <a class="navbar-brand" href="/">
+      <a class="navbar-brand" href="<%= Routes.home_path(@conn, :show) %>">
         <img src="<%= Routes.static_path(@conn, "/images/logo-red.svg") %>">
       </a>
     </div>
 
     <div class="collapse navbar-collapse navbar-ex1-collapse">
       <ul class="nav navbar-nav">
-        <li><a href="/explore">Watch</a></li>
+        <li><a href="<%= Routes.asciicast_path(@conn, :index) %>">Watch</a></li>
         <li><a href="<%= Routes.doc_path(@conn, :show, :"getting-started") %>">Record</a></li>
         <li><a href="<%= Routes.doc_path(@conn, :show, :"how-it-works") %>">Docs</a></li>
         <li><a href="http://blog.asciinema.org">Blog</a></li>
-        <li><a href="/about">About</a></li>
+        <li><a href="<%= Routes.page_path(@conn, :about) %>">About</a></li>
       </ul>
 
       <ul class="nav navbar-nav navbar-right session-info">
@@ -29,12 +29,12 @@
             </a>
             <ul class="dropdown-menu">
               <li><a href="<%= profile_path(@current_user) %>">Profile</a></li>
-              <li><a href="/user/edit">Settings</a></li>
+              <li><a href="<%= Routes.user_path(@conn, :edit) %>">Settings</a></li>
               <li><%= link "Log out", to: Routes.session_path(@conn, :delete), class: "logout", method: :delete %></li>
             </ul>
           </li>
         <% else %>
-          <li><a href="/login/new" id="log-in">Log in / Sign up</a></li>
+          <li><a href="<%= Routes.login_path(@conn, :new) %>" id="log-in">Log in / Sign up</a></li>
         <% end %>
       </ul>
     </div>

--- a/lib/asciinema_web/templates/page/about.html.md
+++ b/lib/asciinema_web/templates/page/about.html.md
@@ -22,12 +22,12 @@ Help the project by [contributing](/contributing) money or time.
 
 ## A bit of history
 
-asciinema project was started by <a href="/~sickill">Marcin Kulik</a>
-([@sickill](https://twitter.com/sickill)) in the beginning of 2011 as
-ascii.io.  He was playing with the idea of sharing terminal session
-recordings on the web since 2010 but the working prototype came to life a bit
-later. asciinema.org site had a first public release in March 2012 (as
-ascii.io then). The project was renamed to "asciinema" in September 2013.
+asciinema project was started by <a href="https://asciinema.org/~sickill">Marcin
+Kulik</a> ([@sickill](https://twitter.com/sickill)) in the beginning of 2011 as
+ascii.io.  He was playing with the idea of sharing terminal session recordings
+on the web since 2010 but the working prototype came to life a bit later.
+asciinema.org site had a first public release in March 2012 (as ascii.io then).
+The project was renamed to "asciinema" in September 2013.
 
 asciinema is actively developed with the help of great open
 source [contributors](https://github.com/asciinema/asciinema-server/contributors).


### PR DESCRIPTION
Fixes #296.

This is a set of patch to allow serving asciinema on other path than /.

It includes:
- Fixing absolute links in the CSS
- Fixing absolute routes in templates
- Fixing absolute routes in controllers

I've tested with locally, including upload, play, registering and connection, all of which seem to work well.