### PR TITLE
Option to disable public sign-ups

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -17,6 +17,11 @@ SECRET_KEY_BASE=
 ## Default: postgresql://postgres@postgres/postgres
 # DATABASE_URL=
 
+## Disable public sign-ups.
+## Set this variable to true or 1 when you don't want new users to sign up.
+## Default: sign up enabled
+# SIGN_UP_DISABLED=true
+
 ## Enable auto-archival of recordings uploaded by anonymous users.
 ## Set this variable to number of days after which the recordings are archived.
 ## Default: unset (no auto-archival)

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -53,3 +53,5 @@ end
 if String.downcase("#{env.("CRON")}") in ["0", "false", "no"] do
   config :asciinema, Oban, plugins: [{Oban.Plugins.Cron, crontab: []}]
 end
+
+config :asciinema, :sign_up_enabled?, env.("SIGN_UP_DISABLED") not in ["1", "true"]

--- a/lib/asciinema_web/controllers/login_controller.ex
+++ b/lib/asciinema_web/controllers/login_controller.ex
@@ -15,7 +15,8 @@ defmodule AsciinemaWeb.LoginController do
       Accounts.send_login_email(
         email_or_username,
         &AsciinemaWeb.signup_url/1,
-        &AsciinemaWeb.login_url/1
+        &AsciinemaWeb.login_url/1,
+        Map.get(conn.assigns, :cfg_sign_up_enabled?, true)
       )
 
     case result do

--- a/lib/asciinema_web/router.ex
+++ b/lib/asciinema_web/router.ex
@@ -11,6 +11,7 @@ defmodule AsciinemaWeb.Router do
     plug :protect_from_forgery
     plug :put_secure_browser_headers
     plug AsciinemaWeb.Auth
+    plug :assign_config
   end
 
   pipeline :asciicast do
@@ -18,6 +19,10 @@ defmodule AsciinemaWeb.Router do
     plug :accepts, ["html", "js", "json", "cast", "svg", "png", "gif"]
     plug :format_specific_plugs
     plug :put_secure_browser_headers
+  end
+
+  defp assign_config(conn, []) do
+    assign(conn, :cfg_sign_up_enabled?, Application.get_env(:asciinema, :sign_up_enabled?, true))
   end
 
   defp format_specific_plugs(conn, []) do

--- a/lib/asciinema_web/templates/layout/_header.html.eex
+++ b/lib/asciinema_web/templates/layout/_header.html.eex
@@ -39,7 +39,10 @@
             </li>
           <% else %>
             <li class="nav-item">
-              <a class="nav-link" href="<%= Routes.login_path(@conn, :new) %>" id="log-in">Log in / Sign up</a>
+              <a class="nav-link" href="<%= Routes.login_path(@conn, :new) %>" id="log-in">
+                Log in
+                <%= if sign_up_enabled?(@conn) do %> / Sign up<% end %>
+              </a>
             </li>
           <% end %>
         </ul>

--- a/lib/asciinema_web/templates/login/new.html.eex
+++ b/lib/asciinema_web/templates/login/new.html.eex
@@ -28,9 +28,14 @@
     <div class="col-md-6">
       <h2><span class="glyphicon glyphicon-info-sign"></span> First time here?</h1>
 
-      <p>We use email-based, passwordless login process. Enter your email
-        address and you'll receive a one-time login link. After you click it
-        you'll get in, and you'll be able to pick your username.</p>
+      <%= if sign_up_enabled?(@conn) do %>
+        <p>We use email-based, passwordless login process. Enter your email
+          address and you'll receive a one-time login link. After you click it
+          you'll get in, and you'll be able to pick your username.</p>
+      <% else %>
+        <p>Public sign up on this site hasn't been enabled. Bummer! Try contacting the
+        administrator.</p>
+      <% end %>
 
       <h2><span class="glyphicon glyphicon-info-sign"></span> Coming back?</h1>
 

--- a/lib/asciinema_web/views/application_view.ex
+++ b/lib/asciinema_web/views/application_view.ex
@@ -26,4 +26,8 @@ defmodule AsciinemaWeb.ApplicationView do
 
   def pluralize(1, thing), do: "1 #{thing}"
   def pluralize(n, thing), do: "#{n} #{Inflex.pluralize(thing)}"
+
+  def sign_up_enabled?(conn) do
+    Map.get(conn.assigns, :cfg_sign_up_enabled?, true)
+  end
 end

--- a/test/asciinema/accounts_test.exs
+++ b/test/asciinema/accounts_test.exs
@@ -12,7 +12,7 @@ defmodule Asciinema.AccountsTest do
     test "existing user, by email" do
       user = fixture(:user)
 
-      assert Accounts.send_login_email(user.email, &signup_url/1, &login_url/1) == :ok
+      assert Accounts.send_login_email(user.email, &signup_url/1, &login_url/1, true) == :ok
 
       assert_enqueued(
         worker: Asciinema.Emails.Job,
@@ -23,7 +23,7 @@ defmodule Asciinema.AccountsTest do
     test "existing user, by username" do
       user = fixture(:user)
 
-      assert Accounts.send_login_email(user.username, &signup_url/1, &login_url/1) == :ok
+      assert Accounts.send_login_email(user.username, &signup_url/1, &login_url/1, true) == :ok
 
       assert_enqueued(
         worker: Asciinema.Emails.Job,
@@ -32,7 +32,8 @@ defmodule Asciinema.AccountsTest do
     end
 
     test "non-existing user, by email" do
-      assert Accounts.send_login_email("new@example.com", &signup_url/1, &login_url/1) == :ok
+      assert Accounts.send_login_email("new@example.com", &signup_url/1, &login_url/1, true) ==
+               :ok
 
       assert_enqueued(
         worker: Asciinema.Emails.Job,
@@ -40,15 +41,22 @@ defmodule Asciinema.AccountsTest do
       )
     end
 
+    test "non-existing user, by email, when sign up is disabled" do
+      assert Accounts.send_login_email("new@example.com", &signup_url/1, &login_url/1, false) ==
+               {:error, :user_not_found}
+
+      refute_enqueued(worker: Asciinema.Emails.Job)
+    end
+
     test "non-existing user, by email, when email is invalid" do
-      assert Accounts.send_login_email("new@", &signup_url/1, &login_url/1) ==
+      assert Accounts.send_login_email("new@", &signup_url/1, &login_url/1, true) ==
                {:error, :email_invalid}
 
       refute_enqueued(worker: Asciinema.Emails.Job)
     end
 
     test "non-existing user, by username" do
-      assert Accounts.send_login_email("idontexist", &signup_url/1, &login_url/1) ==
+      assert Accounts.send_login_email("idontexist", &signup_url/1, &login_url/1, true) ==
                {:error, :user_not_found}
 
       refute_enqueued(worker: Asciinema.Emails.Job)


### PR DESCRIPTION
Set `SIGN_UP_DISABLED=true` env var to prevent people from creating new accounts (provided `.env.production.sample` file has it).

Closes #325 