### PR TITLE
[docker-compose]: Fix issue about migration to postgresql 12

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     restart: unless-stopped
     volumes:
       - ./volumes/postgres:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_HOST_AUTH_METHOD=trust
     ### See https://hub.docker.com/_/postgres/ for more
     ### configuration options for this image.
 


### PR DESCRIPTION
From postgresql 11 or 12, we can't use an empty password by default.

You may:
- Define a password (`POSTGRES_PASSWORD`)
- Set `trust` as auth method `(POSTGRES_HOST_AUTH_METHOD=trust`)

The easiest way to fix it right is to use the trust auth method, but it should be better in a production environment to set a password instead.

Thank you for your work.