### PR TITLE
Update docs to use latest FreeBSD package name

### DIFF
--- a/lib/asciinema_web/templates/doc/installation.html.md
+++ b/lib/asciinema_web/templates/doc/installation.html.md
@@ -89,7 +89,7 @@ For Fedora >= 22:
 
 ### Packages
 
-    pkg install py37-asciinema
+    pkg install py39-asciinema
 
 ## Installing on OpenBSD
 {: #installing-on-openbsd}


### PR DESCRIPTION
With updates to the default version of Python, the package name has changed from `py37-asciinema` to `py39-asciinema`.

Fixes #404.