### PR TITLE
Use Cargo Sparse protocol in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG ALPINE_VERSION=3.17.0
+ARG ALPINE_VERSION=3.18.0
 ARG ERLANG_OTP_VERSION=25.2.2
 ARG ELIXIR_VERSION=1.14.3
 
@@ -9,6 +9,9 @@ FROM docker.io/hexpm/elixir:${ELIXIR_VERSION}-erlang-${ERLANG_OTP_VERSION}-alpin
 
 ARG MIX_ENV=prod
 ENV ERL_FLAGS="+JPperf true"
+# Avoid "error 137" (out of memory) while building images
+# See https://github.com/rust-lang/cargo/issues/10781
+ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL="sparse"
 
 WORKDIR /opt/app
 


### PR DESCRIPTION
Cargo 1.68 and newer introduced "sparse" protocol which significantly reduces memory usage (and improves build time!) - see https://blog.rust-lang.org/inside-rust/2023/01/30/cargo-sparse-protocol.html

Had to bump Alpine to 3.18 to pick up a more recent Cargo release (1.76.0)

hexpm/elixir do not sure Alpine 3.19 with current erlang+elixir combination

Should fix [the CI error 137](https://github.com/asciinema/asciinema-server/actions/runs/8862606635/job/24336135766#step:6:532) on current main

```
#26 [linux/arm64 builder  5/18] RUN cd native/vt_nif && cargo build -r
#26 2.171     Updating crates.io index
#26 ERROR: process "/dev/.buildkit_qemu_emulator /bin/sh -c cd native/vt_nif && cargo build -r" did not complete successfully: exit code: 137
```

