### PR TITLE
set tzdata data_dir in config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -112,6 +112,9 @@ config :asciinema, Oban,
 config :scrivener_html,
   view_style: :bootstrap_v4
 
+# set tzdata data_dir out of the app dir for tzdata self-update mechanism
+config :tzdata, :data_dir, Path.expand("/tmp/tzdata")
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{config_env()}.exs"


### PR DESCRIPTION
tzdata has a auto-update mechanism as described [here](https://github.com/lau/tzdata?tab=readme-ov-file#data-directory-and-releases) If you operate asciinema in a Pod of a Kuberntes cluster with readOnlyRootFilesystem this will cause CrashLoopBackOff due the missing write permissions in the depth of the application directory. So move out this directory to `/tmp/tzdata`, so it can be mount by an emptyDir. At startup tzdata will fill this directory automatically:

```
06:43:43.238 [info] No tzdata release files found in custom data dir. Copying release file from tzdata priv dir.
```

Another option would be [disable](https://github.com/lau/tzdata?tab=readme-ov-file#automatic-data-updates) the tzdata update feature